### PR TITLE
Handle partial socket reads

### DIFF
--- a/AVNC/MainFrm.cs
+++ b/AVNC/MainFrm.cs
@@ -87,8 +87,8 @@ namespace AVNC
 
                     try
                     {
-                        mySocket.Receive(bReceive, bReceive.Length, 0);
-                        sBuffer = Encoding.ASCII.GetString(bReceive);
+                        int receivedBytes = mySocket.Receive(bReceive, bReceive.Length, SocketFlags.None);
+                        sBuffer = Encoding.ASCII.GetString(bReceive, 0, receivedBytes);
 
                         if (sBuffer.Length > 0)
                         {


### PR DESCRIPTION
## Summary
- respect actual bytes read from socket when handling HTTP requests
- avoid extraneous data by decoding only the received portion of the buffer

## Testing
- `msbuild AVNC/AVNC.sln` (fails: command not found)
- `dotnet build AVNC/AVNC.csproj` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68957226a0fc832fb43a81681c857567