### PR TITLE
Ignore favicon requests in request log

### DIFF
--- a/AVNC/MainFrm.cs
+++ b/AVNC/MainFrm.cs
@@ -92,7 +92,7 @@ namespace AVNC
 
                         if (sBuffer.Length > 0)
                         {
-                            if (sBuffer.Split(' ')[1] != "Get /favicon.ico")
+                            if (!sBuffer.StartsWith("GET /favicon.ico"))
                                 Invoke(new onAddLog(addLog), "Req: " + sBuffer.Split(' ')[1], sBuffer);
                             else
                                 sBuffer = "";


### PR DESCRIPTION
## Summary
- correctly detect `/favicon.ico` requests in `startListening`
- avoid logging or processing favicon requests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `python3` script simulating `GET /favicon.ico` request


------
https://chatgpt.com/codex/tasks/task_e_68957425a370832fa7b66c3a003a4657