### PR TITLE
Upgrade project to .NET 9

### DIFF
--- a/AVNC/AVNC.csproj
+++ b/AVNC/AVNC.csproj
@@ -1,164 +1,29 @@
-﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="3.5">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.21022</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{7779D7C3-D8A7-4783-B980-FD0BD2F15D5C}</ProjectGuid>
     <OutputType>WinExe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>AVNC</RootNamespace>
-    <AssemblyName>AVNC</AssemblyName>
-    <ApplicationIcon>Resources\main.ico</ApplicationIcon>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
-    <OldToolsVersion>2.0</OldToolsVersion>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
-    <ManifestCertificateThumbprint>FDDFFF0CC7BA445589E750E97142F1B449B072F8</ManifestCertificateThumbprint>
-    <ManifestKeyFile>AVNC_TemporaryKey.pfx</ManifestKeyFile>
-    <GenerateManifests>true</GenerateManifests>
-    <SignManifests>false</SignManifests>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>1</ApplicationRevision>
-    <ApplicationVersion>1.5.2.%2a</ApplicationVersion>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TargetFramework>net9.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ApplicationIcon>Resources/main.ico</ApplicationIcon>
+    <EnableUnsafeBlocks>true</EnableUnsafeBlocks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Deployment" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Classes\CompareImages.cs" />
-    <Compile Include="Classes\HTMLWrapper.cs" />
-    <Compile Include="Classes\Log.cs" />
-    <Compile Include="Classes\OctreeQuantizer.cs" />
-    <Compile Include="Classes\Piece.cs" />
-    <Compile Include="Classes\Quantizer.cs" />
-    <Compile Include="LogViewer.cs">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Include="LogViewer.Designer.cs">
-      <DependentUpon>LogViewer.cs</DependentUpon>
-    </Compile>
-    <Compile Include="MainFrm.cs">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Include="MainFrm.Designer.cs">
-      <DependentUpon>MainFrm.cs</DependentUpon>
-    </Compile>
-    <Compile Include="Classes\MouseAndKeyboard.cs" />
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <EmbeddedResource Include="LogViewer.resx">
-      <SubType>Designer</SubType>
-      <DependentUpon>LogViewer.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Include="MainFrm.resx">
-      <SubType>Designer</SubType>
-      <DependentUpon>MainFrm.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Properties\Resources.resx">
+    <None Update="Properties/Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <Compile Include="Properties\Resources.Designer.cs">
+    </None>
+    <Compile Update="Properties/Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
-      <DesignTime>True</DesignTime>
     </Compile>
-    <None Include="Properties\Settings.settings">
+    <None Update="Properties/Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
-    <Compile Include="Properties\Settings.Designer.cs">
+    <Compile Update="Properties/Settings.Designer.cs">
       <AutoGen>True</AutoGen>
       <DependentUpon>Settings.settings</DependentUpon>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="Resources\main.ico" />
-  </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework Client Profile</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.2.0">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 2.0 %28x86%29</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.0">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.0 %28x86%29</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Windows.Installer.3.1">
-      <Visible>False</Visible>
-      <ProductName>Windows Installer 3.1</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
-  <PropertyGroup>
-    <PostBuildEvent>
-    </PostBuildEvent>
-  </PropertyGroup>
 </Project>

--- a/AVNC/AVNC.sln
+++ b/AVNC/AVNC.sln
@@ -1,20 +1,21 @@
-﻿
-Microsoft Visual Studio Solution File, Format Version 10.00
-# Visual C# Express 2008
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AVNC", "AVNC.csproj", "{7779D7C3-D8A7-4783-B980-FD0BD2F15D5C}"
 EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{7779D7C3-D8A7-4783-B980-FD0BD2F15D5C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7779D7C3-D8A7-4783-B980-FD0BD2F15D5C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7779D7C3-D8A7-4783-B980-FD0BD2F15D5C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7779D7C3-D8A7-4783-B980-FD0BD2F15D5C}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
+        GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                Debug|Any CPU = Debug|Any CPU
+                Release|Any CPU = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {7779D7C3-D8A7-4783-B980-FD0BD2F15D5C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {7779D7C3-D8A7-4783-B980-FD0BD2F15D5C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {7779D7C3-D8A7-4783-B980-FD0BD2F15D5C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {7779D7C3-D8A7-4783-B980-FD0BD2F15D5C}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
+                HideSolutionNode = FALSE
+        EndGlobalSection
 EndGlobal

--- a/AVNC/MainFrm.cs
+++ b/AVNC/MainFrm.cs
@@ -9,7 +9,6 @@ using System.Net.Sockets;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
-using System.Web;
 using System.Windows.Forms;
 using AVNC.Classes;
 using Microsoft.Win32;
@@ -239,7 +238,7 @@ namespace AVNC
             //string key;
             str = str.Split(' ')[1];
             str = str.Trim().Substring(14); // cause its GET[0] /sendStroke[1]{x}{x}... [2]http accept
-            str = HttpUtility.UrlDecode(str);
+            str = WebUtility.UrlDecode(str);
             try
             {
                 SendMK.sendKeystroke(str.ToString());

--- a/README.txt
+++ b/README.txt
@@ -1,1 +1,3 @@
 Make sure the files in "Needed" folder are in the same directory as the exe application, otherwise you will get an error when you try to run the application.
+
+This project now targets .NET 9.0. Install the .NET 9 runtime to build or run the application.


### PR DESCRIPTION
## Summary
- migrate AVNC to a modern SDK-style project targeting `net9.0-windows` with Windows Forms support
- replace obsolete `HttpUtility` usage with `WebUtility` for cross-platform URL decoding
- document .NET 9 requirement in README and refresh solution for Visual Studio 17

## Testing
- `dotnet build AVNC/AVNC.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689575869474832fb7c8b1a62dd7162d